### PR TITLE
Rename MyStandardScaler and fix to work with dataframes

### DIFF
--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -1,6 +1,4 @@
-import numpy as np
 from sklearn.neighbors import KNeighborsRegressor
-from sklearn.preprocessing import StandardScaler
 from sklearn.utils.validation import check_is_fitted
 
 
@@ -23,10 +21,3 @@ class TransformedKNeighborsMixin(KNeighborsRegressor):
         return super().kneighbors(
             X=X, n_neighbors=n_neighbors, return_distance=return_distance
         )
-
-
-class MyStandardScaler(StandardScaler):
-    def fit(self, X, y=None, sample_weight=None):
-        sc = super().fit(X, y, sample_weight)
-        sc.scale_ = np.std(X, axis=0, ddof=1)
-        return sc

--- a/src/sknnr/_euclidean.py
+++ b/src/sknnr/_euclidean.py
@@ -1,11 +1,12 @@
 from sklearn.utils.validation import check_is_fitted
 
-from ._base import IDNeighborsRegressor, MyStandardScaler, TransformedKNeighborsMixin
+from ._base import IDNeighborsRegressor, TransformedKNeighborsMixin
+from .transformers import StandardScalerWithDOF
 
 
 class EuclideanKNNRegressor(IDNeighborsRegressor, TransformedKNeighborsMixin):
     def fit(self, X, y):
-        self.transform_ = MyStandardScaler().fit(X)
+        self.transform_ = StandardScalerWithDOF(ddof=1).fit(X)
         X = self.transform_.transform(X)
         return super().fit(X, y)
 

--- a/src/sknnr/_gnn.py
+++ b/src/sknnr/_gnn.py
@@ -1,7 +1,7 @@
 from sklearn.utils.validation import check_is_fitted
 
 from ._base import IDNeighborsRegressor, TransformedKNeighborsMixin
-from .transformers._cca_transformer import CCATransformer
+from .transformers import CCATransformer
 
 
 class GNNRegressor(IDNeighborsRegressor, TransformedKNeighborsMixin):

--- a/src/sknnr/_mahalanobis.py
+++ b/src/sknnr/_mahalanobis.py
@@ -1,7 +1,7 @@
 from sklearn.utils.validation import check_is_fitted
 
 from ._base import IDNeighborsRegressor, TransformedKNeighborsMixin
-from .transformers._mahalanobis_transformer import MahalanobisTransformer
+from .transformers import MahalanobisTransformer
 
 
 class MahalanobisKNNRegressor(IDNeighborsRegressor, TransformedKNeighborsMixin):

--- a/src/sknnr/transformers/__init__.py
+++ b/src/sknnr/transformers/__init__.py
@@ -1,0 +1,3 @@
+from ._standard_scaler_dof import StandardScalerWithDOF
+
+__all__ = ["StandardScalerWithDOF"]

--- a/src/sknnr/transformers/__init__.py
+++ b/src/sknnr/transformers/__init__.py
@@ -1,3 +1,5 @@
-from ._standard_scaler_dof import StandardScalerWithDOF
+from ._base import StandardScalerWithDOF
+from ._cca_transformer import CCATransformer
+from ._mahalanobis_transformer import MahalanobisTransformer
 
-__all__ = ["StandardScalerWithDOF"]
+__all__ = ["StandardScalerWithDOF", "CCATransformer", "MahalanobisTransformer"]

--- a/src/sknnr/transformers/_base.py
+++ b/src/sknnr/transformers/_base.py
@@ -9,5 +9,5 @@ class StandardScalerWithDOF(StandardScaler):
 
     def fit(self, X, y=None, sample_weight=None):
         scaler = super().fit(X, y, sample_weight)
-        scaler.scale_ = np.std(np.array(X), axis=0, ddof=self.ddof)
+        scaler.scale_ = np.std(np.asarray(X), axis=0, ddof=self.ddof)
         return scaler

--- a/src/sknnr/transformers/_cca_transformer.py
+++ b/src/sknnr/transformers/_cca_transformer.py
@@ -1,3 +1,4 @@
+import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 
 from ._cca import CCA
@@ -6,6 +7,7 @@ from ._cca import CCA
 class CCATransformer(TransformerMixin, BaseEstimator):
     def fit(self, X, y=None, spp=None):
         y = spp if spp is not None else y
+        X, y = np.asarray(X), np.asarray(y)
         self.cca_ = CCA(X, y)
         return self
 

--- a/src/sknnr/transformers/_mahalanobis_transformer.py
+++ b/src/sknnr/transformers/_mahalanobis_transformer.py
@@ -1,12 +1,12 @@
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 
-from .._base import MyStandardScaler
+from . import StandardScalerWithDOF
 
 
 class MahalanobisTransformer(TransformerMixin, BaseEstimator):
     def fit(self, X, y=None):
-        self.scaler_ = MyStandardScaler().fit(X)
+        self.scaler_ = StandardScalerWithDOF(ddof=1).fit(X)
         covariance = np.cov(self.scaler_.transform(X), rowvar=False)
         self.transform_ = np.linalg.inv(np.linalg.cholesky(covariance).T)
         return self

--- a/src/sknnr/transformers/_standard_scaler_dof.py
+++ b/src/sknnr/transformers/_standard_scaler_dof.py
@@ -1,0 +1,13 @@
+import numpy as np
+from sklearn.preprocessing import StandardScaler
+
+
+class StandardScalerWithDOF(StandardScaler):
+    def __init__(self, ddof=0):
+        super().__init__()
+        self.ddof = ddof
+
+    def fit(self, X, y=None, sample_weight=None):
+        scaler = super().fit(X, y, sample_weight)
+        scaler.scale_ = np.std(np.array(X), axis=0, ddof=self.ddof)
+        return scaler

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -57,8 +57,8 @@ def test_estimators_support_continuous_multioutput(estimator, moscow_euclidean):
 
 
 @pytest.mark.parametrize("estimator", get_kneighbor_estimator_instances())
-def test_estimators_support_multioutput_dataframes(estimator, moscow_euclidean):
-    """All estimators should fit and predict multioutput data stored as dataframe."""
-    X_df = pd.DataFrame(moscow_euclidean.X)
-    estimator.fit(X_df, moscow_euclidean.y)
+def test_estimators_support_dataframes(estimator, moscow_euclidean):
+    """All estimators should fit and predict data stored as dataframes."""
+    X_df, y_df = pd.DataFrame(moscow_euclidean.X), pd.DataFrame(moscow_euclidean.y)
+    estimator.fit(X_df, y_df)
     estimator.predict(X_df)

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -1,5 +1,6 @@
 from typing import List
 
+import pandas as pd
 import pytest
 
 # from sklearn.utils.estimator_checks import parametrize_with_checks
@@ -53,3 +54,11 @@ def test_estimators_support_continuous_multioutput(estimator, moscow_euclidean):
     """All estimators should fit and predict continuous multioutput data."""
     estimator.fit(moscow_euclidean.X, moscow_euclidean.y)
     estimator.predict(moscow_euclidean.X)
+
+
+@pytest.mark.parametrize("estimator", get_kneighbor_estimator_instances())
+def test_estimators_support_multioutput_dataframes(estimator, moscow_euclidean):
+    """All estimators should fit and predict multioutput data stored as dataframe."""
+    X_df = pd.DataFrame(moscow_euclidean.X)
+    estimator.fit(X_df, moscow_euclidean.y)
+    estimator.predict(X_df)


### PR DESCRIPTION
This addresses issues raised in both #6 and #15.

- `MyStandardScaler` renamed to `StandardScalerWithDOF`
- Moved into `transformers` directory
- Cast dataframe to array before setting `scale_` attribute
- Add new test to check dataframe compliance