### PR TITLE
Simplify fit parameters for `CCATransformer` and `CCorATransformer`

### DIFF
--- a/src/sknnr/_gnn.py
+++ b/src/sknnr/_gnn.py
@@ -3,6 +3,7 @@ from .transformers import CCATransformer
 
 
 class GNNRegressor(IDNeighborsRegressor, TransformedKNeighborsMixin):
-    def fit(self, X, y, spp=None):
-        self.transform_ = CCATransformer().fit(X, y=y, spp=spp)
+    def fit(self, X, y, y_fit=None):
+        y_fit = y_fit if y_fit is not None else y
+        self.transform_ = CCATransformer().fit(X, y=y_fit)
         return super().fit(X, y)

--- a/src/sknnr/_msn.py
+++ b/src/sknnr/_msn.py
@@ -3,6 +3,7 @@ from .transformers import CCorATransformer
 
 
 class MSNRegressor(IDNeighborsRegressor, TransformedKNeighborsMixin):
-    def fit(self, X, y, spp=None):
-        self.transform_ = CCorATransformer().fit(X, y=y, spp=spp)
+    def fit(self, X, y, y_fit=None):
+        y_fit = y_fit if y_fit is not None else y
+        self.transform_ = CCorATransformer().fit(X, y=y_fit)
         return super().fit(X, y)

--- a/src/sknnr/transformers/_cca_transformer.py
+++ b/src/sknnr/transformers/_cca_transformer.py
@@ -5,8 +5,7 @@ from ._cca import CCA
 
 
 class CCATransformer(TransformerMixin, BaseEstimator):
-    def fit(self, X, y=None, spp=None):
-        y = spp if spp is not None else y
+    def fit(self, X, y):
         X, y = np.asarray(X), np.asarray(y)
         self.cca_ = CCA(X, y)
         return self
@@ -16,6 +15,5 @@ class CCATransformer(TransformerMixin, BaseEstimator):
         X = X @ self.cca_.coefficients
         return X @ self.cca_.axis_weights
 
-    def fit_transform(self, X, y=None, spp=None):
-        y = spp if spp is not None else y
+    def fit_transform(self, X, y):
         return self.fit(X, y).transform(X)

--- a/src/sknnr/transformers/_ccora_transformer.py
+++ b/src/sknnr/transformers/_ccora_transformer.py
@@ -5,8 +5,7 @@ from ._ccora import CCorA
 
 
 class CCorATransformer(TransformerMixin, BaseEstimator):
-    def fit(self, X, y=None, spp=None):
-        y = spp if spp is not None else y
+    def fit(self, X, y):
         self.scaler_ = StandardScalerWithDOF(ddof=1).fit(X)
         y = StandardScalerWithDOF(ddof=1).fit_transform(y)
         self.ccora_ = CCorA(self.scaler_.transform(X), y)
@@ -15,6 +14,5 @@ class CCorATransformer(TransformerMixin, BaseEstimator):
     def transform(self, X, y=None):
         return self.scaler_.transform(X) @ self.ccora_.projector
 
-    def fit_transform(self, X, y=None, spp=None):
-        y = spp if spp is not None else y
+    def fit_transform(self, X, y):
         return self.fit(X, y).transform(X)

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -62,10 +62,10 @@ def test_moscow_mahalanobis(moscow_mahalanobis):
 
 
 def test_moscow_msn(moscow_msn):
-    X_train, X_test, y_train, _, y_spp, _ = train_test_split(
+    X_train, X_test, y_train, _, y_fit, _ = train_test_split(
         moscow_msn.X, moscow_msn.ids, moscow_msn.y, train_size=0.8, shuffle=False
     )
-    clf = MSNRegressor(n_neighbors=5).fit(X_train, y_train, spp=y_spp)
+    clf = MSNRegressor(n_neighbors=5).fit(X_train, y_train, y_fit=y_fit)
 
     dist, nn = clf.kneighbors()
 
@@ -79,10 +79,10 @@ def test_moscow_msn(moscow_msn):
 
 
 def test_moscow_gnn(moscow_gnn):
-    X_train, X_test, y_train, _, y_spp, _ = train_test_split(
+    X_train, X_test, y_train, _, y_fit, _ = train_test_split(
         moscow_gnn.X, moscow_gnn.ids, moscow_gnn.y, train_size=0.8, shuffle=False
     )
-    clf = GNNRegressor(n_neighbors=5).fit(X_train, y_train, spp=y_spp)
+    clf = GNNRegressor(n_neighbors=5).fit(X_train, y_train, y_fit=y_fit)
 
     dist, nn = clf.kneighbors()
 


### PR DESCRIPTION
This will close #30 by:

1. Making `y` a required parameter for fitting `CCATransformer` and `CCorATransformer`.
2. Making `GNNRegressor` and `MSNRegressor` choose the appropriate fitting data instead of the transformer.
3. Renaming `spp` to `y_fit` throughout.