### PR TITLE
Dataframe compatibility for transformers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 ]
 dependencies = [
     "numpy",
-    "scikit-learn",
+    "scikit-learn>=1.2",
     "scipy",
 ]
 

--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -1,11 +1,10 @@
 import warnings
-from contextlib import contextmanager
-from typing import Literal
 
 import numpy as np
-from sklearn.base import BaseEstimator
 from sklearn.neighbors import KNeighborsRegressor
 from sklearn.utils.validation import _get_feature_names, check_is_fitted
+
+from .transformers._base import set_temp_output
 
 
 class IDNeighborsRegressor(KNeighborsRegressor):
@@ -80,15 +79,3 @@ class TransformedKNeighborsMixin(KNeighborsRegressor):
         return super().kneighbors(
             X=X_transformed, n_neighbors=n_neighbors, return_distance=return_distance
         )
-
-
-@contextmanager
-def set_temp_output(estimator: BaseEstimator, temp_mode: Literal["default", "pandas"]):
-    """Temporarily set the output mode of an estimator."""
-    previous_config = getattr(estimator, "_sklearn_output_config", {}).copy()
-
-    estimator.set_output(transform=temp_mode)
-    try:
-        yield
-    finally:
-        estimator._sklearn_output_config = previous_config

--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -1,24 +1,11 @@
+import warnings
+from contextlib import contextmanager
+from typing import Literal
+
 import numpy as np
+from sklearn.base import BaseEstimator
 from sklearn.neighbors import KNeighborsRegressor
-from sklearn.utils.validation import check_is_fitted
-
-
-class NamedFeatureArray(np.ndarray):
-    """An array with a columns attribute indicating feature names.
-
-    Storing a `columns` attribute allows this array to act like  a dataframe for the
-    purpose of extracting feature names when passed to sklearn estimators.
-    """
-
-    def __new__(cls, array, columns=None):
-        obj = np.asarray(array).view(cls)
-        obj.columns = columns
-        return obj
-
-    def __array_finalize__(self, obj):
-        if obj is None:
-            return
-        self.columns = getattr(obj, "columns", None)
+from sklearn.utils.validation import _get_feature_names, check_is_fitted
 
 
 class IDNeighborsRegressor(KNeighborsRegressor):
@@ -32,20 +19,53 @@ class TransformedKNeighborsMixin(KNeighborsRegressor):
     Mixin for KNeighbors regressors that apply transformations to the feature data.
     """
 
-    def _apply_transform(self, X) -> NamedFeatureArray:
-        """Apply the stored transform to the input data.
+    @property
+    def feature_names_in_(self):
+        return self.transform_.feature_names_in_
 
-        Note
-        ----
-        Transforming will cast input data to numpy arrays. To preserve feature names
-        in the case of dataframe inputs, this method will wrap the transformed array
-        in a `NamedFeatureArray` with a `columns` attribute, allowing `sklearn` to
-        parse and store feature names.
+    def _check_feature_names(self, X, *, reset):
+        """Override BaseEstimator._check_feature_names to prevent errors.
+
+        REFERENCE: https://github.com/scikit-learn/scikit-learn/blob/849c2f10f56b908abd9abbbffca8941494cc0bb0/sklearn/base.py#L409  # noqa: E501
+        This is identical to the sklearn implementation except that:
+
+        1. The reset option is ignored to avoid setting feature names.
+        2. The second half of the method that validates X feature names against the
+              fitted feature names is removed. This is because we want estimators to
+              return the feature names that were used to fit the transformer, not the
+              feature names that were used to fit the estimator.
         """
+        fitted_feature_names = getattr(self, "feature_names_in_", None)
+        X_feature_names = _get_feature_names(X)
+
+        if fitted_feature_names is None and X_feature_names is None:
+            return
+
+        if X_feature_names is not None and fitted_feature_names is None:
+            warnings.warn(
+                f"X has feature names, but {self.__class__.__name__} was fitted without"
+                " feature names",
+                stacklevel=2,
+            )
+            return
+
+        if X_feature_names is None and fitted_feature_names is not None:
+            warnings.warn(
+                "X does not have valid feature names, but"
+                f" {self.__class__.__name__} was fitted with feature names",
+                stacklevel=2,
+            )
+            return
+
+    def _apply_transform(self, X) -> np.ndarray:
+        """Apply the stored transform to the input data."""
         check_is_fitted(self, "transform_")
-        X_transformed = self.transform_.transform(X)
-        if hasattr(X, "columns"):
-            X_transformed = NamedFeatureArray(X_transformed, columns=X.columns)
+
+        # Temporarily run the transformer in pandas mode for dataframe inputs to ensure
+        # that features are passed through to subsequent steps.
+        output_mode = "pandas" if hasattr(X, "iloc") else "default"
+        with set_temp_output(self.transform_, temp_mode=output_mode):  # type: ignore
+            X_transformed = self.transform_.transform(X)
 
         return X_transformed
 
@@ -60,3 +80,15 @@ class TransformedKNeighborsMixin(KNeighborsRegressor):
         return super().kneighbors(
             X=X_transformed, n_neighbors=n_neighbors, return_distance=return_distance
         )
+
+
+@contextmanager
+def set_temp_output(estimator: BaseEstimator, temp_mode: Literal["default", "pandas"]):
+    """Temporarily set the output mode of an estimator."""
+    previous_config = getattr(estimator, "_sklearn_output_config", {}).copy()
+
+    estimator.set_output(transform=temp_mode)
+    try:
+        yield
+    finally:
+        estimator._sklearn_output_config = previous_config

--- a/src/sknnr/transformers/_base.py
+++ b/src/sknnr/transformers/_base.py
@@ -1,4 +1,8 @@
+from contextlib import contextmanager
+from typing import Literal
+
 import numpy as np
+from sklearn.base import TransformerMixin
 from sklearn.preprocessing import StandardScaler
 
 
@@ -11,3 +15,17 @@ class StandardScalerWithDOF(StandardScaler):
         scaler = super().fit(X, y, sample_weight)
         scaler.scale_ = np.std(np.asarray(X), axis=0, ddof=self.ddof)
         return scaler
+
+
+@contextmanager
+def set_temp_output(
+    transformer: TransformerMixin, temp_mode: Literal["default", "pandas"]
+):
+    """Temporarily set the output mode of an transformer."""
+    previous_config = getattr(transformer, "_sklearn_output_config", {}).copy()
+
+    transformer.set_output(transform=temp_mode)
+    try:
+        yield
+    finally:
+        transformer._sklearn_output_config = previous_config

--- a/src/sknnr/transformers/_base.py
+++ b/src/sknnr/transformers/_base.py
@@ -21,7 +21,7 @@ class StandardScalerWithDOF(StandardScaler):
 def set_temp_output(
     transformer: TransformerMixin, temp_mode: Literal["default", "pandas"]
 ):
-    """Temporarily set the output mode of an transformer."""
+    """Temporarily set the output mode of a transformer."""
     previous_config = getattr(transformer, "_sklearn_output_config", {}).copy()
 
     transformer.set_output(transform=temp_mode)

--- a/src/sknnr/transformers/_cca_transformer.py
+++ b/src/sknnr/transformers/_cca_transformer.py
@@ -1,5 +1,6 @@
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
 
 from ._cca import CCA
 
@@ -15,13 +16,18 @@ class CCATransformer(TransformerMixin, BaseEstimator):
         )
 
     def fit(self, X, y):
-        X = self._validate_data(X, reset=True)
+        self._validate_data(
+            X, reset=True, dtype=FLOAT_DTYPES, force_all_finite="allow-nan"
+        )
 
         X, y = np.asarray(X), np.asarray(y)
         self.cca_ = CCA(X, y)
         return self
 
     def transform(self, X, y=None):
+        check_is_fitted(self)
+        X = np.asarray(X)
+
         X = X - self.cca_.env_center
         X = X @ self.cca_.coefficients
         return X @ self.cca_.axis_weights

--- a/src/sknnr/transformers/_cca_transformer.py
+++ b/src/sknnr/transformers/_cca_transformer.py
@@ -5,7 +5,18 @@ from ._cca import CCA
 
 
 class CCATransformer(TransformerMixin, BaseEstimator):
+    @property
+    def _n_features_out(self):
+        return self.cca_.eigenvalues.shape[0]
+
+    def get_feature_names_out(self, input_features=None) -> np.ndarray:
+        return np.asarray(
+            [f"cca{i}" for i in range(self._n_features_out)], dtype=object
+        )
+
     def fit(self, X, y):
+        X = self._validate_data(X, reset=True)
+
         X, y = np.asarray(X), np.asarray(y)
         self.cca_ = CCA(X, y)
         return self

--- a/src/sknnr/transformers/_cca_transformer.py
+++ b/src/sknnr/transformers/_cca_transformer.py
@@ -10,7 +10,7 @@ class CCATransformer(TransformerMixin, BaseEstimator):
     def _n_features_out(self):
         return self.cca_.eigenvalues.shape[0]
 
-    def get_feature_names_out(self, input_features=None) -> np.ndarray:
+    def get_feature_names_out(self) -> np.ndarray:
         return np.asarray(
             [f"cca{i}" for i in range(self._n_features_out)], dtype=object
         )

--- a/src/sknnr/transformers/_ccora_transformer.py
+++ b/src/sknnr/transformers/_ccora_transformer.py
@@ -22,7 +22,7 @@ class CCorATransformer(
         )
 
     def fit(self, X, y):
-        X = self._validate_data(X, reset=True)
+        self._validate_data(X, reset=True)
 
         self.scaler_ = StandardScalerWithDOF(ddof=1).fit(X)
         y = StandardScalerWithDOF(ddof=1).fit_transform(y)

--- a/src/sknnr/transformers/_ccora_transformer.py
+++ b/src/sknnr/transformers/_ccora_transformer.py
@@ -1,11 +1,29 @@
-from sklearn.base import BaseEstimator, TransformerMixin
+import numpy as np
+from sklearn.base import (
+    BaseEstimator,
+    ClassNamePrefixFeaturesOutMixin,
+    TransformerMixin,
+)
 
 from . import StandardScalerWithDOF
 from ._ccora import CCorA
 
 
-class CCorATransformer(TransformerMixin, BaseEstimator):
+class CCorATransformer(
+    ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator
+):
+    @property
+    def _n_features_out(self):
+        return self.ccora_.projector.shape[1]
+
+    def get_feature_names_out(self, input_features=None) -> np.ndarray:
+        return np.asarray(
+            [f"ccora{i}" for i in range(self._n_features_out)], dtype=object
+        )
+
     def fit(self, X, y):
+        X = self._validate_data(X, reset=True)
+
         self.scaler_ = StandardScalerWithDOF(ddof=1).fit(X)
         y = StandardScalerWithDOF(ddof=1).fit_transform(y)
         self.ccora_ = CCorA(self.scaler_.transform(X), y)

--- a/src/sknnr/transformers/_ccora_transformer.py
+++ b/src/sknnr/transformers/_ccora_transformer.py
@@ -1,22 +1,16 @@
 import numpy as np
-from sklearn.base import (
-    BaseEstimator,
-    ClassNamePrefixFeaturesOutMixin,
-    TransformerMixin,
-)
+from sklearn.base import BaseEstimator, TransformerMixin
 
 from . import StandardScalerWithDOF
 from ._ccora import CCorA
 
 
-class CCorATransformer(
-    ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator
-):
+class CCorATransformer(TransformerMixin, BaseEstimator):
     @property
     def _n_features_out(self):
         return self.ccora_.projector.shape[1]
 
-    def get_feature_names_out(self, input_features=None) -> np.ndarray:
+    def get_feature_names_out(self) -> np.ndarray:
         return np.asarray(
             [f"ccora{i}" for i in range(self._n_features_out)], dtype=object
         )

--- a/src/sknnr/transformers/_ccora_transformer.py
+++ b/src/sknnr/transformers/_ccora_transformer.py
@@ -1,5 +1,6 @@
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.utils.validation import check_is_fitted
 
 from . import StandardScalerWithDOF
 from ._ccora import CCorA
@@ -24,6 +25,7 @@ class CCorATransformer(TransformerMixin, BaseEstimator):
         return self
 
     def transform(self, X, y=None):
+        check_is_fitted(self)
         return self.scaler_.transform(X) @ self.ccora_.projector
 
     def fit_transform(self, X, y):

--- a/src/sknnr/transformers/_mahalanobis_transformer.py
+++ b/src/sknnr/transformers/_mahalanobis_transformer.py
@@ -1,11 +1,13 @@
 import numpy as np
-from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.base import BaseEstimator, OneToOneFeatureMixin, TransformerMixin
 
 from . import StandardScalerWithDOF
 
 
-class MahalanobisTransformer(TransformerMixin, BaseEstimator):
+class MahalanobisTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
     def fit(self, X, y=None):
+        X = self._validate_data(X, reset=True)
+
         self.scaler_ = StandardScalerWithDOF(ddof=1).fit(X)
         covariance = np.cov(self.scaler_.transform(X), rowvar=False)
         self.transform_ = np.linalg.inv(np.linalg.cholesky(covariance).T)

--- a/src/sknnr/transformers/_mahalanobis_transformer.py
+++ b/src/sknnr/transformers/_mahalanobis_transformer.py
@@ -6,7 +6,7 @@ from . import StandardScalerWithDOF
 
 class MahalanobisTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
     def fit(self, X, y=None):
-        X = self._validate_data(X, reset=True)
+        self._validate_data(X, reset=True)
 
         self.scaler_ = StandardScalerWithDOF(ddof=1).fit(X)
         covariance = np.cov(self.scaler_.transform(X), rowvar=False)

--- a/src/sknnr/transformers/_mahalanobis_transformer.py
+++ b/src/sknnr/transformers/_mahalanobis_transformer.py
@@ -1,5 +1,6 @@
 import numpy as np
 from sklearn.base import BaseEstimator, OneToOneFeatureMixin, TransformerMixin
+from sklearn.utils.validation import check_is_fitted
 
 from . import StandardScalerWithDOF
 
@@ -14,6 +15,7 @@ class MahalanobisTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimat
         return self
 
     def transform(self, X, y=None):
+        check_is_fitted(self)
         return self.scaler_.transform(X) @ self.transform_
 
     def fit_transform(self, X, y=None):

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Type
 
 import pandas as pd
 import pytest
@@ -19,7 +19,7 @@ from sknnr import (
 from sknnr._base import IDNeighborsRegressor
 
 
-def get_kneighbor_estimator_classes() -> List[IDNeighborsRegressor]:
+def get_kneighbor_estimator_classes() -> List[Type[IDNeighborsRegressor]]:
     """
     Return classes of all supported IDNeighborsRegressor estimators.
     """

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -3,6 +3,8 @@ from typing import List
 import pandas as pd
 import pytest
 from numpy.testing import assert_array_equal
+from sklearn import set_config
+from sklearn.neighbors import KNeighborsRegressor
 
 # from sklearn.utils.estimator_checks import parametrize_with_checks
 from sklearn.utils.validation import NotFittedError
@@ -17,17 +19,24 @@ from sknnr import (
 from sknnr._base import IDNeighborsRegressor
 
 
+def get_kneighbor_estimator_classes() -> List[IDNeighborsRegressor]:
+    """
+    Return classes of all supported IDNeighborsRegressor estimators.
+    """
+    return [
+        RawKNNRegressor,
+        EuclideanKNNRegressor,
+        MahalanobisKNNRegressor,
+        MSNRegressor,
+        GNNRegressor,
+    ]
+
+
 def get_kneighbor_estimator_instances() -> List[IDNeighborsRegressor]:
     """
     Return instances of all supported IDNeighborsRegressor estimators.
     """
-    return [
-        RawKNNRegressor(),
-        EuclideanKNNRegressor(),
-        MahalanobisKNNRegressor(),
-        MSNRegressor(),
-        GNNRegressor(),
-    ]
+    return [cls() for cls in get_kneighbor_estimator_classes()]
 
 
 # Note: This will run all the sklearn estimator checks. It's going to take quite a bit
@@ -38,30 +47,32 @@ def get_kneighbor_estimator_instances() -> List[IDNeighborsRegressor]:
 #     check(estimator)
 
 
-@pytest.mark.parametrize("estimator", get_kneighbor_estimator_instances())
+@pytest.mark.parametrize("estimator", get_kneighbor_estimator_classes())
 def test_estimators_raise_notfitted_kneighbors(estimator, moscow_euclidean):
     """Attempting to call kneighbors on an unfitted estimator should raise."""
     with pytest.raises(NotFittedError):
-        estimator.kneighbors(moscow_euclidean.X)
+        estimator().kneighbors(moscow_euclidean.X)
 
 
-@pytest.mark.parametrize("estimator", get_kneighbor_estimator_instances())
+@pytest.mark.parametrize("estimator", get_kneighbor_estimator_classes())
 def test_estimators_raise_notfitted_predict(estimator, moscow_euclidean):
     """Attempting to call predict on an unfitted estimator should raise."""
     with pytest.raises(NotFittedError):
-        estimator.predict(moscow_euclidean.X)
+        estimator().predict(moscow_euclidean.X)
 
 
-@pytest.mark.parametrize("estimator", get_kneighbor_estimator_instances())
+@pytest.mark.parametrize("estimator", get_kneighbor_estimator_classes())
 def test_estimators_support_continuous_multioutput(estimator, moscow_euclidean):
     """All estimators should fit and predict continuous multioutput data."""
+    estimator = estimator()
     estimator.fit(moscow_euclidean.X, moscow_euclidean.y)
     estimator.predict(moscow_euclidean.X)
 
 
-@pytest.mark.parametrize("estimator", get_kneighbor_estimator_instances())
+@pytest.mark.parametrize("estimator", get_kneighbor_estimator_classes())
 def test_estimators_support_dataframes(estimator, moscow_euclidean):
     """All estimators should fit and predict data stored as dataframes."""
+    estimator = estimator()
     num_features = moscow_euclidean.X.shape[1]
     feature_names = [f"col_{i}" for i in range(num_features)]
 
@@ -71,3 +82,48 @@ def test_estimators_support_dataframes(estimator, moscow_euclidean):
     estimator.fit(X_df, y_df)
     estimator.predict(X_df)
     assert_array_equal(estimator.feature_names_in_, feature_names)
+
+
+@pytest.mark.parametrize("estimator", get_kneighbor_estimator_classes())
+def test_estimators_warn_for_missing_features(estimator, moscow_euclidean):
+    """All estimators should warn when fitting and predicting feature names mismatch."""
+    estimator = estimator()
+    num_features = moscow_euclidean.X.shape[1]
+    feature_names = [f"col_{i}" for i in range(num_features)]
+
+    X = moscow_euclidean.X
+    y = moscow_euclidean.y
+    X_df = pd.DataFrame(X, columns=feature_names)
+
+    # Fit without feature names, predict with feature names
+    with pytest.warns(UserWarning, match="fitted without feature names"):
+        estimator.fit(X, y)
+        estimator.predict(X_df)
+
+    # Fit with feature names, predict without feature names
+    with pytest.warns(UserWarning, match="fitted with feature names"):
+        estimator.fit(X_df, y)
+        estimator.predict(X)
+
+
+@pytest.mark.parametrize("output_mode", ["default", "pandas"])
+@pytest.mark.parametrize("x_type", ["array", "dataframe"])
+@pytest.mark.parametrize("estimator", get_kneighbor_estimator_classes())
+def test_estimator_output_type_consistency(
+    output_mode, x_type, estimator, moscow_euclidean
+):
+    """Test that output types are consistent with an sklearn estimator."""
+    X, y = moscow_euclidean.X, moscow_euclidean.y
+    X_df = pd.DataFrame(X, columns=[f"col_{i}" for i in range(X.shape[1])])
+    x = X if x_type == "array" else X_df
+
+    estimator = estimator()
+    ref_estimator = KNeighborsRegressor()
+
+    # Transformer config should not affect estimator output
+    set_config(transform_output=output_mode)
+
+    sknnr_type = type(estimator.fit(x, y).predict(x))
+    ref_type = type(ref_estimator.fit(x, y).predict(x))
+
+    assert sknnr_type is ref_type  # noqa: E721

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -1,5 +1,11 @@
+import numpy as np
+import pandas as pd
 import pytest
+from numpy.testing import assert_array_equal
+from sklearn import set_config
+from sklearn.preprocessing import StandardScaler
 
+from sknnr._base import set_temp_output
 from sknnr.transformers import (
     CCATransformer,
     CCorATransformer,
@@ -8,29 +14,102 @@ from sknnr.transformers import (
 )
 
 
-def get_transformer_instances():
+def get_transformer_classes():
     """
-    Return instances of all supported transformers.
+    Return classes of all supported transformers.
     """
     return [
-        StandardScalerWithDOF(),
-        MahalanobisTransformer(),
-        CCATransformer(),
-        CCorATransformer(),
+        StandardScalerWithDOF,
+        MahalanobisTransformer,
+        CCATransformer,
+        CCorATransformer,
     ]
 
 
-@pytest.mark.parametrize("transformer", get_transformer_instances())
+@pytest.mark.parametrize("transformer", get_transformer_classes())
 def test_transformers_get_feature_names_out(transformer, moscow_euclidean):
     """Test that all transformers get the correct number of feature names out."""
-    fit_transformer = transformer.fit(X=moscow_euclidean.X, y=moscow_euclidean.y)
+    fit_transformer = transformer().fit(X=moscow_euclidean.X, y=moscow_euclidean.y)
     feature_names = fit_transformer.get_feature_names_out()
     X_transformed = fit_transformer.transform(X=moscow_euclidean.X)
 
     assert feature_names.shape == (X_transformed.shape[1],)
 
 
-@pytest.mark.parametrize("transformer", get_transformer_instances())
-def test_transformers_have_setoutput(transformer):
-    """Test that all transformers can use set_output."""
-    assert transformer.set_output() is not None
+@pytest.mark.parametrize("config_type", ["global", "transformer"])
+@pytest.mark.parametrize("output_mode", ["default", "pandas"])
+@pytest.mark.parametrize("x_type", ["array", "dataframe"])
+@pytest.mark.parametrize("transformer", get_transformer_classes())
+def test_transformer_output_type_consistency(
+    config_type, output_mode, x_type, transformer, moscow_euclidean
+):
+    """Test that output types are consistent with an sklearn transformer."""
+    X, y = moscow_euclidean.X, moscow_euclidean.y
+    X_df = pd.DataFrame(X, columns=[f"col_{i}" for i in range(X.shape[1])])
+    x = X if x_type == "array" else X_df
+
+    transformer = transformer()
+    ref_transformer = StandardScaler()
+
+    if config_type == "global":
+        set_config(transform_output=output_mode)
+
+    else:
+        transformer.set_output(transform=output_mode)
+        ref_transformer.set_output(transform=output_mode)
+
+    sknnr_type = type(transformer.fit_transform(x, y))
+    ref_type = type(ref_transformer.fit_transform(x, y))
+
+    assert sknnr_type is ref_type  # noqa: E721
+
+
+@pytest.mark.parametrize("config_type", ["global", "transformer"])
+@pytest.mark.parametrize("output_mode", ["default", "pandas"])
+@pytest.mark.parametrize("x_type", ["array", "dataframe"])
+@pytest.mark.parametrize("transformer", get_transformer_classes())
+def test_transformer_feature_consistency(
+    config_type, output_mode, x_type, transformer, moscow_euclidean
+):
+    """Test that feature names are consistent with an sklearn transformer."""
+    X, y = moscow_euclidean.X, moscow_euclidean.y
+    x = (
+        X
+        if x_type == "array"
+        else pd.DataFrame(X, columns=[f"col_{i}" for i in range(X.shape[1])])
+    )
+    transformer = transformer()
+    ref_transformer = StandardScaler()
+
+    if config_type == "global":
+        set_config(transform_output=output_mode)
+
+    else:
+        transformer.set_output(transform=output_mode)
+        ref_transformer.set_output(transform=output_mode)
+
+    if hasattr(ref_transformer.fit(x, y), "feature_names_in_"):
+        assert_array_equal(
+            transformer.fit(x, y).feature_names_in_,
+            ref_transformer.fit(x, y).feature_names_in_,
+        )
+    else:
+        assert not hasattr(transformer.fit(x, y), "feature_names_in_")
+
+
+@pytest.mark.parametrize("config_type", ["global", "transformer"])
+def test_set_temp_output(moscow_euclidean, config_type):
+    """Test that set_temp_output works as expected."""
+    transformer = StandardScaler().fit(moscow_euclidean.X, moscow_euclidean.y)
+
+    if config_type == "global":
+        set_config(transform_output="pandas")
+    else:
+        transformer.set_output(transform="pandas")
+
+    # Temp output mode should override previously set config
+    with set_temp_output(estimator=transformer, temp_mode="default"):
+        assert isinstance(transformer.transform(moscow_euclidean.X), np.ndarray)
+
+    # Previous config should be restored
+    assert isinstance(transformer.transform(moscow_euclidean.X), pd.DataFrame)

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -1,8 +1,11 @@
+from typing import List, Type
+
 import numpy as np
 import pandas as pd
 import pytest
 from numpy.testing import assert_array_equal
 from sklearn import set_config
+from sklearn.base import TransformerMixin
 from sklearn.preprocessing import StandardScaler
 
 from sknnr._base import set_temp_output
@@ -14,7 +17,7 @@ from sknnr.transformers import (
 )
 
 
-def get_transformer_classes():
+def get_transformer_classes() -> List[Type[TransformerMixin]]:
     """
     Return classes of all supported transformers.
     """

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_array_equal
 from sklearn import set_config
 from sklearn.base import TransformerMixin
 from sklearn.preprocessing import StandardScaler
+from sklearn.utils.validation import NotFittedError
 
 from sknnr._base import set_temp_output
 from sknnr.transformers import (
@@ -98,6 +99,13 @@ def test_transformer_feature_consistency(
         )
     else:
         assert not hasattr(transformer.fit(x, y), "feature_names_in_")
+
+
+@pytest.mark.parametrize("transformer", get_transformer_classes())
+def test_transformers_raise_notfitted_transform(transformer, moscow_euclidean):
+    """Attempting to call transform on an unfitted transformer should raise."""
+    with pytest.raises(NotFittedError):
+        transformer().transform(moscow_euclidean.X)
 
 
 @pytest.mark.parametrize("config_type", ["global", "transformer"])

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -111,7 +111,7 @@ def test_set_temp_output(moscow_euclidean, config_type):
         transformer.set_output(transform="pandas")
 
     # Temp output mode should override previously set config
-    with set_temp_output(estimator=transformer, temp_mode="default"):
+    with set_temp_output(transformer=transformer, temp_mode="default"):
         assert isinstance(transformer.transform(moscow_euclidean.X), np.ndarray)
 
     # Previous config should be restored

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -1,0 +1,36 @@
+import pytest
+
+from sknnr.transformers import (
+    CCATransformer,
+    CCorATransformer,
+    MahalanobisTransformer,
+    StandardScalerWithDOF,
+)
+
+
+def get_transformer_instances():
+    """
+    Return instances of all supported transformers.
+    """
+    return [
+        StandardScalerWithDOF(),
+        MahalanobisTransformer(),
+        CCATransformer(),
+        CCorATransformer(),
+    ]
+
+
+@pytest.mark.parametrize("transformer", get_transformer_instances())
+def test_transformers_get_feature_names_out(transformer, moscow_euclidean):
+    """Test that all transformers get the correct number of feature names out."""
+    fit_transformer = transformer.fit(X=moscow_euclidean.X, y=moscow_euclidean.y)
+    feature_names = fit_transformer.get_feature_names_out()
+    X_transformed = fit_transformer.transform(X=moscow_euclidean.X)
+
+    assert feature_names.shape == (X_transformed.shape[1],)
+
+
+@pytest.mark.parametrize("transformer", get_transformer_instances())
+def test_transformers_have_setoutput(transformer):
+    """Test that all transformers can use set_output."""
+    assert transformer.set_output() is not None


### PR DESCRIPTION
This PR closes #20 by making our transformers compatible with the [set_output API](https://scikit-learn.org/stable/auto_examples/miscellaneous/plot_set_output.html), allowing them to output dataframes based on configuration.

@grovduck, this ballooned into a pretty big PR, so I could definitely use a second set of eyes to make sure I didn't go off the rails anywhere! I tried to lay out the details and reasoning of the big changes below. Most of these were discussed in the issue, but a few things came up during implementation. Happy to discuss anything!

### set_output

This method is [automatically available](https://github.com/scikit-learn/scikit-learn/blob/689efe2f25356aa674bd0090f44b0914aae4d3a3/sklearn/utils/_set_output.py#L213) for all `BaseEstimator` subclasses via the `_SetOutputMixin` once they have a `get_feature_names_out` method.


### get_feature_names_out

This was already available for `StandardScalerWithDOF` via `OneToOneFeatureMixin`, and [adding that subclass to `MahalanobisTransformer`](https://github.com/lemma-osu/scikit-learn-knn-regression/blob/21da829f14c74419abf8d655c7e6a85f5d05249d/src/sknnr/transformers/_mahalanobis_transformer.py#L7) made it available there. 

`CCATransformer` and `CCorATransformer` can't use that subclass due to dimensionality reduction. We considered using [ClassNamePrefixFeaturesOutMixin](https://scikit-learn.org/stable/modules/generated/sklearn.base.ClassNamePrefixFeaturesOutMixin.html) but decided against it since the feature names would be too long (e.g. `ccatransformer0`. Instead, we just [implement the method from scratch](https://github.com/lemma-osu/scikit-learn-knn-regression/blob/21da829f14c74419abf8d655c7e6a85f5d05249d/src/sknnr/transformers/_cca_transformer.py#L13) for those two transformers. This required adding an `_n_features_out` property, which is [based on the shape of the `eigenvalues` and `projector`](https://github.com/lemma-osu/scikit-learn-knn-regression/blob/21da829f14c74419abf8d655c7e6a85f5d05249d/src/sknnr/transformers/_cca_transformer.py#L10) attributes, respectively. These should continue to work even if additional dimensionality reduction is added by #33.


### feature_names_in_

After some discussion, we decided that `feature_names_in_` for our transformed estimators should return the names of the original features passed by the user rather than the transformed features that are used internally to fit the estimator. To implement that, we add a [corresponding property](https://github.com/lemma-osu/scikit-learn-knn-regression/blob/21da829f14c74419abf8d655c7e6a85f5d05249d/src/sknnr/_base.py#L23) that just grabs the attr from the stored `transform_`. 

### _check_feature_names

Predicting with a `KNeighborsRegressor` runs a variety of checks via `_validate_data`. One of those checks, `_check_feature_names`, will fail if the feature names of `X` don't match the `feature_names_in_` that were stored during fitting. Because we override that property, we also need to [override this check](https://github.com/lemma-osu/scikit-learn-knn-regression/blob/21da829f14c74419abf8d655c7e6a85f5d05249d/src/sknnr/_base.py#L26) to avoid that error. However, if we still want to raise warnings when feature names are missing entirely, we need to copy the relevant portion of that method from sklearn, which will need to be licensed under BSD-3. Those warnings are tested by `test_estimators_warn_for_missing_features`.

@grovduck, how important do you think those warnings are? During my usage of sklearn they've never alerted me to any bugs (and have mostly just annoyed me when I'm intentionally using array data after fitting with a dataframe), but if we're aiming for maximum consistency, I suppose we should probably keep them? It just adds a little maintenance and licensing complexity. The alternative would be to just override with an empty check that does nothing.


### Pinning sklearn

The `set_output` API and a few helper classes (including `OneToOneFeatureMixin`) were added in [`scikit-learn=1.2` in Dec. 2022](https://scikit-learn.org/stable/whats_new/v1.2.html#changes-1-2), so this [pins to that release](https://github.com/lemma-osu/scikit-learn-knn-regression/blob/21da829f14c74419abf8d655c7e6a85f5d05249d/pyproject.toml#L18). I don't love that restriction since it's still a relatively recent release, but we rely pretty heavily on its functionality so I don't see a good alternative. 

### Removing NamedFeatureArray

Previously, we had to use `NamedFeatureArray` to persist feature names after they were removed by transformers in our transformed estimators. Now, we can use `set_output` on the transformer based on the type of the input data, so that dataframes (and feature names) are preserved through transformation. To avoid permanently changing configuration on the transformer, this is done with a helper function [`set_temp_output`](https://github.com/lemma-osu/scikit-learn-knn-regression/blob/21da829f14c74419abf8d655c7e6a85f5d05249d/src/sknnr/_base.py#L86) that resets transformer configuration once it's done. Note that I'm currently using the [presence of an `iloc` attribute](https://github.com/lemma-osu/scikit-learn-knn-regression/blob/21da829f14c74419abf8d655c7e6a85f5d05249d/src/sknnr/_base.py#L66) on `X` to determine if it's a dataframe. This isn't a perfect approach, but it seems to be the go-to in sklearn ([for example](https://github.com/search?q=repo%3Ascikit-learn%2Fscikit-learn%20hasattr(X%2C%20%22iloc%22)&type=code)).


### Consistency tests

This PR adds a *lot* of new tests. The majority of these are what I'm calling ["consistency" tests](https://github.com/lemma-osu/scikit-learn-knn-regression/blob/21da829f14c74419abf8d655c7e6a85f5d05249d/tests/test_transformers.py#L46), which just test that our transformers and estimators behave similarly to a reference from `sklearn` in terms of attributes and output types. I think this is a pretty unconventional way to test, but given that consistency with `sklearn` is one of our priorities, it seemed like a reasonable approach. The alternative would be to map out what the output types should be under all of these conditions and then manually test against those, rather than against the reference implementations. 