### PR TITLE
Fix broken warning and reduce complexity of feature validation #35

### DIFF
--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -1,10 +1,6 @@
-import warnings
-
 import numpy as np
 from sklearn.neighbors import KNeighborsRegressor
-from sklearn.utils.validation import _get_feature_names, check_is_fitted
-
-from .transformers._base import set_temp_output
+from sklearn.utils.validation import check_is_fitted
 
 
 class IDNeighborsRegressor(KNeighborsRegressor):
@@ -25,48 +21,17 @@ class TransformedKNeighborsMixin(KNeighborsRegressor):
     def _check_feature_names(self, X, *, reset):
         """Override BaseEstimator._check_feature_names to prevent errors.
 
-        REFERENCE: https://github.com/scikit-learn/scikit-learn/blob/849c2f10f56b908abd9abbbffca8941494cc0bb0/sklearn/base.py#L409  # noqa: E501
-        This is identical to the sklearn implementation except that:
-
-        1. The reset option is ignored to avoid setting feature names.
-        2. The second half of the method that validates X feature names against the
-              fitted feature names is removed. This is because we want estimators to
-              return the feature names that were used to fit the transformer, not the
-              feature names that were used to fit the estimator.
+        This check would fail during fitting because `feature_names_in_` stores original
+        names while X contains transformed names. We instead rely on the transformer to
+        check feature names and warn or raise for mismatches.
         """
-        fitted_feature_names = getattr(self, "feature_names_in_", None)
-        X_feature_names = _get_feature_names(X)
-
-        if fitted_feature_names is None and X_feature_names is None:
-            return
-
-        if X_feature_names is not None and fitted_feature_names is None:
-            warnings.warn(
-                f"X has feature names, but {self.__class__.__name__} was fitted without"
-                " feature names",
-                stacklevel=2,
-            )
-            return
-
-        if X_feature_names is None and fitted_feature_names is not None:
-            warnings.warn(
-                "X does not have valid feature names, but"
-                f" {self.__class__.__name__} was fitted with feature names",
-                stacklevel=2,
-            )
-            return
+        return
 
     def _apply_transform(self, X) -> np.ndarray:
         """Apply the stored transform to the input data."""
         check_is_fitted(self, "transform_")
-
-        # Temporarily run the transformer in pandas mode for dataframe inputs to ensure
-        # that features are passed through to subsequent steps.
-        output_mode = "pandas" if hasattr(X, "iloc") else "default"
-        with set_temp_output(self.transform_, temp_mode=output_mode):  # type: ignore
-            X_transformed = self.transform_.transform(X)
-
-        return X_transformed
+        self.transform_._validate_data(X, reset=False)
+        return self.transform_.transform(X)
 
     def fit(self, X, y):
         """Fit using transformed feature data."""

--- a/src/sknnr/transformers/_base.py
+++ b/src/sknnr/transformers/_base.py
@@ -1,8 +1,4 @@
-from contextlib import contextmanager
-from typing import Literal
-
 import numpy as np
-from sklearn.base import TransformerMixin
 from sklearn.preprocessing import StandardScaler
 
 
@@ -15,17 +11,3 @@ class StandardScalerWithDOF(StandardScaler):
         scaler = super().fit(X, y, sample_weight)
         scaler.scale_ = np.std(np.asarray(X), axis=0, ddof=self.ddof)
         return scaler
-
-
-@contextmanager
-def set_temp_output(
-    transformer: TransformerMixin, temp_mode: Literal["default", "pandas"]
-):
-    """Temporarily set the output mode of a transformer."""
-    previous_config = getattr(transformer, "_sklearn_output_config", {}).copy()
-
-    transformer.set_output(transform=temp_mode)
-    try:
-        yield
-    finally:
-        transformer._sklearn_output_config = previous_config

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -1,6 +1,5 @@
 from typing import List, Type
 
-import numpy as np
 import pandas as pd
 import pytest
 from numpy.testing import assert_array_equal
@@ -9,7 +8,6 @@ from sklearn.base import TransformerMixin
 from sklearn.preprocessing import StandardScaler
 from sklearn.utils.validation import NotFittedError
 
-from sknnr._base import set_temp_output
 from sknnr.transformers import (
     CCATransformer,
     CCorATransformer,
@@ -106,21 +104,3 @@ def test_transformers_raise_notfitted_transform(transformer, moscow_euclidean):
     """Attempting to call transform on an unfitted transformer should raise."""
     with pytest.raises(NotFittedError):
         transformer().transform(moscow_euclidean.X)
-
-
-@pytest.mark.parametrize("config_type", ["global", "transformer"])
-def test_set_temp_output(moscow_euclidean, config_type):
-    """Test that set_temp_output works as expected."""
-    transformer = StandardScaler().fit(moscow_euclidean.X, moscow_euclidean.y)
-
-    if config_type == "global":
-        set_config(transform_output="pandas")
-    else:
-        transformer.set_output(transform="pandas")
-
-    # Temp output mode should override previously set config
-    with set_temp_output(transformer=transformer, temp_mode="default"):
-        assert isinstance(transformer.transform(moscow_euclidean.X), np.ndarray)
-
-    # Previous config should be restored
-    assert isinstance(transformer.transform(moscow_euclidean.X), pd.DataFrame)


### PR DESCRIPTION
This closes #35 and simplifies feature validation. [This comment](https://github.com/lemma-osu/scikit-learn-knn-regression/issues/35#issuecomment-1583088921) and [this commit](https://github.com/lemma-osu/scikit-learn-knn-regression/commit/b213566d5270ce34764eddba6faa6383e3a5381e) go into more depth on the changes here, but the bullet points are:

1. Remove `set_temp_output` because we no longer need transformers to pass dataframes into transformed estimators since we can get feature names from the transformer.
2. Remove the warning logic from `TransformedKNeighborsMixin._check_feature_names`. That is now handled by calling `transform_._validate_data`. This method now just serves to override the internal check that would incorrectly fail when our estimator is fit with transformed features that mismatch the `feature_names_in_` from the transformer.
3. Update tests to make sure we can fit with a dataframe with no feature names without getting a warning.
4. Parametrize a few related test cases just to improve error reporting.