### PR TITLE
Store repeatedly used variables as estimator attributes #47

### DIFF
--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -70,7 +70,6 @@ class TransformedKNeighborsMixin:
     def _apply_transform(self, X) -> NDArray:
         """Apply the stored transform to the input data."""
         check_is_fitted(self, "transform_")
-        self.transform_._validate_data(X, reset=False)
         return self.transform_.transform(X)
 
     def fit(self, X, y):

--- a/src/sknnr/transformers/_cca_transformer.py
+++ b/src/sknnr/transformers/_cca_transformer.py
@@ -23,6 +23,8 @@ class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
         y = np.asarray(y)
         self.ordination_ = CCA(X, y)
         self.set_n_components()
+        self.env_center_ = self.ordination_.env_center
+        self.projector_ = self.ordination_.projector(n_components=self.n_components_)
         return self
 
     def transform(self, X, y=None):
@@ -35,10 +37,7 @@ class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
             ensure_min_features=2,
             ensure_min_samples=1,
         )
-
-        return (X - self.ordination_.env_center) @ self.ordination_.projector(
-            n_components=self.n_components_
-        )
+        return (X - self.env_center_) @ self.projector_
 
     def fit_transform(self, X, y):
         return self.fit(X, y).transform(X)

--- a/src/sknnr/transformers/_ccora_transformer.py
+++ b/src/sknnr/transformers/_ccora_transformer.py
@@ -18,14 +18,13 @@ class CCorATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
 
         self.ordination_ = CCorA(self.scaler_.transform(X), y)
         self.set_n_components()
+        self.projector_ = self.ordination_.projector(n_components=self.n_components_)
         return self
 
     def transform(self, X, y=None):
         check_is_fitted(self)
         self._validate_data(X, reset=False, force_all_finite=True)
-        return self.scaler_.transform(X) @ self.ordination_.projector(
-            n_components=self.n_components_
-        )
+        return self.scaler_.transform(X) @ self.projector_
 
     def fit_transform(self, X, y):
         return self.fit(X, y).transform(X)


### PR DESCRIPTION
For `CCATransformer` and `CCorATransformer`, store matrices from ordination as estimator attributes within `fit` method.  Previously, we were calling properties from `CCA` and `CCorA` (respectively) that were recomputing expensive operations.  Because the matrix projectors don't change once fit, it's more efficient to store as estimator attributes.

Also, remove redundant call to `_validate_data` in `TransformedKNeighborsMixin._apply_transform` as the transformers are now responsible for that call.