### PR TITLE
Only store array-like `dataframe_index_in_` and fix `CCA` compability with `list`

### DIFF
--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 from sklearn.base import TransformerMixin
 from sklearn.neighbors import KNeighborsRegressor
-from sklearn.utils.validation import check_is_fitted
+from sklearn.utils.validation import _is_arraylike, check_is_fitted
 
 
 class DFIndexCrosswalkMixin:
@@ -11,8 +11,9 @@ class DFIndexCrosswalkMixin:
 
     def _set_dataframe_index_in(self, X):
         """Store dataframe indexes if X is a dataframe."""
-        if hasattr(X, "index"):
-            self.dataframe_index_in_ = np.asarray(X.index)
+        index = getattr(X, "index", None)
+        if _is_arraylike(index):
+            self.dataframe_index_in_ = np.asarray(index)
 
 
 class IndependentPredictorMixin:

--- a/src/sknnr/transformers/_cca_transformer.py
+++ b/src/sknnr/transformers/_cca_transformer.py
@@ -16,11 +16,10 @@ class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
             ensure_min_features=2,
             ensure_min_samples=1,
         )
-
-        if not hasattr(y, "shape") or len(y.shape) < 2:
+        y = np.asarray(y)
+        if len(y.shape) < 2:
             raise ValueError("`y` must be a 2D array.")
 
-        y = np.asarray(y)
         self.ordination_ = CCA(X, y)
         self.set_n_components()
         self.env_center_ = self.ordination_.env_center

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -80,6 +80,10 @@ def test_estimators_support_dataframe_indexes(estimator):
     with pytest.raises(NotFittedError, match="fitted with a dataframe"):
         estimator.kneighbors(return_dataframe_index=True)
 
+    # Make sure that `list.index()` is not accidentally stored
+    estimator.fit(moscow.data.tolist(), moscow.target)
+    assert not hasattr(estimator, "dataframe_index_in_")
+
     estimator.fit(X_df, moscow.target)
     assert_array_equal(estimator.dataframe_index_in_, moscow.index)
 

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -93,6 +93,14 @@ def test_estimators_support_dataframe_indexes(estimator):
 
 
 @pytest.mark.parametrize("estimator", TEST_ESTIMATORS)
+def test_estimators_support_lists(estimator):
+    """All estimators should fit and predict data stored as lists."""
+    X, y = load_moscow_stjoes(return_X_y=True)
+    estimator = estimator().fit(X.tolist(), y.tolist())
+    estimator.predict(X.tolist())
+
+
+@pytest.mark.parametrize("estimator", TEST_ESTIMATORS)
 def test_estimators_support_dataframes(estimator):
     """All estimators should fit and predict data stored as dataframes."""
     X, y = load_moscow_stjoes(return_X_y=True, as_frame=True)


### PR DESCRIPTION
This resolves #55 by only storing the `dataframe_index_in_` if it's array-like, and updates `test_estimators_support_dataframe_indexes` to confirm that the `list.index` method isn't accidentally stored like it previously was.

While testing this I noticed a small bug that prevented fitting `CCATransformer` with a `y: list` due to the dimensionality check. Just changing the order of casting and checking shape solved that, so I included it here as a quick fix.