### PR TITLE
Add `3.12` to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,16 +8,16 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # sknnr
 
+[![ReadTheDocs](https://readthedocs.org/projects/sknnr/badge/?version=latest)](https://sknnr.readthedocs.io/en/latest)
+
 > ⚠️ **WARNING: sknnr is in active development!** ⚠️
 
 ## What is sknnr?


### PR DESCRIPTION
The biggest change is adding `3.12` to our CI now that it's officially out (we're passing!), but I also bumped a few actions to the latest versions and added a docs badge to the readme while I was at it. @grovduck I hope you don't mind the combined PR!